### PR TITLE
Refactor PHP handlers with shared utilities

### DIFF
--- a/common.php
+++ b/common.php
@@ -1,0 +1,38 @@
+<?php
+function get_db_connection() {
+    require "/var/www/html8443/mallapi/db_info.php";
+    $db_conn = mysqli_connect($db_host, $db_user, $db_pwd, $db_category, $db_port);
+    if (mysqli_connect_errno()) {
+        die("DB 연결 실패: " . mysqli_connect_error());
+    }
+    return $db_conn;
+}
+
+function log_write($order_item_code, $log_data, $file_name, $log_dir) {
+    $dir = rtrim($log_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+    $oldUmask = umask(002);
+    if (!is_dir($dir) && !mkdir($dir, 0775, true)) {
+        umask($oldUmask);
+        throw new RuntimeException("로그 디렉터리 생성 실패: {$dir}");
+    }
+    umask($oldUmask);
+
+    $time = date('c');
+    $sanitized = preg_replace('/[^A-Za-z0-9_\-]/', '', $order_item_code);
+    $body = is_string($log_data) ? $log_data : json_encode($log_data, JSON_UNESCAPED_UNICODE);
+    if ($body === false) {
+        $jsonError = function_exists('json_last_error_msg') ? json_last_error_msg() : 'JSON encoding error';
+        throw new RuntimeException('JSON 인코딩 실패: ' . $jsonError);
+    }
+
+    $logTxt = "\n({$sanitized} {$time})\n{$body}\n\n";
+    $path = $dir . $file_name;
+    if (is_file($path) && filesize($path) > 10 * 1024 * 1024) {
+        rename($path, $path . '.' . date('Ymd_His'));
+    }
+    if (file_put_contents($path, $logTxt, FILE_APPEND | LOCK_EX) === false) {
+        throw new RuntimeException("로그 파일 쓰기 실패: {$path}");
+    }
+    return true;
+}
+?>

--- a/run_failed_esim_handler.php
+++ b/run_failed_esim_handler.php
@@ -7,12 +7,11 @@ error_reporting(E_ALL);
 // 타임존 설정
 date_default_timezone_set("Asia/Seoul");
 
-// 데이터베이스 연결 설정
-require "/var/www/html8443/mallapi/db_info.php";
-$db_conn = mysqli_connect($db_host, $db_user, $db_pwd, $db_category, $db_port);
-if (mysqli_connect_errno()) {
-    die("DB 연결 실패: " . mysqli_connect_error());
-}
+// 공통 함수
+require __DIR__ . '/common.php';
+
+// 데이터베이스 연결
+$db_conn = get_db_connection();
 
 // 필요한 라이브러리 포함
 include_once "/var/www/html/mobile_app/mgr/phpbarcode/src/BarcodeGeneratorPNG.php";
@@ -387,55 +386,6 @@ while ($row = mysqli_fetch_assoc($rs)) {
 // 데이터베이스 연결 종료
 mysqli_close($db_conn);
 
-function log_write($order_item_code, $log_data, $file_name, $log_dir)
-{
-    /* 1) 경로 안전 조합 */
-    $dir = rtrim($log_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-
-    /* 2) 디렉터리 생성(775/664) */
-    $oldUmask = umask(002);
-    if (!is_dir($dir)) {
-        if (!mkdir($dir, 0775, true)) {
-            umask($oldUmask);
-            throw new RuntimeException("로그 디렉터리 생성 실패: {$dir}");
-        }
-    }
-    umask($oldUmask);
-
-    /* 3) 로그 라인 생성 */
-    $time = date('c');                                   // ISO-8601
-    $sanitized = preg_replace('/[^A-Za-z0-9_\-]/', '', $order_item_code);
-
-    if (is_string($log_data)) {
-        $body = $log_data;
-    } else {
-        $body = json_encode($log_data, JSON_UNESCAPED_UNICODE);
-        if ($body === false) {
-            // PHP 5.3~5.4에 json_last_error_msg()가 없으므로 별도 처리
-            $jsonError = function_exists('json_last_error_msg')
-                ? json_last_error_msg()
-                : 'JSON encoding error';
-            throw new RuntimeException('JSON 인코딩 실패: ' . $jsonError);
-        }
-    }
-
-    $logTxt = "\n({$sanitized} {$time})\n{$body}\n\n";
-
-    /* 4) 파일 쓰기(append + lock) */
-    $path = $dir . $file_name;
-
-    // 10 MB 초과 시 간단 로테이션
-    if (is_file($path) && filesize($path) > 10 * 1024 * 1024) {
-        rename($path, $path . '.' . date('Ymd_His'));
-    }
-
-    // LOCK_EX 상수는 PHP 5.1 이상에서 지원
-    if (file_put_contents($path, $logTxt, FILE_APPEND | LOCK_EX) === false) {
-        throw new RuntimeException("로그 파일 쓰기 실패: {$path}");
-    }
-
-    return true;
-}
 // 모든 로직이 정상적으로 완료되었을 때 아래 코드 실행
 if ($failed) {
     $cnt = count($failed);

--- a/run_failed_usim_handler.php
+++ b/run_failed_usim_handler.php
@@ -8,12 +8,11 @@ mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
 // 타임존 설정
 date_default_timezone_set("Asia/Seoul");
 
-// 데이터베이스 연결 정보
-require "/var/www/html8443/mallapi/db_info.php";
-$db_conn = mysqli_connect($db_host, $db_user, $db_pwd, $db_category, $db_port);
-if (mysqli_connect_errno()) {
-    die("DB 연결 실패: " . mysqli_connect_error());
-}
+// 공통 함수
+require __DIR__ . '/common.php';
+
+// 데이터베이스 연결
+$db_conn = get_db_connection();
 
 // 요청 파라미터 확인
 if (!$_REQUEST['retry_start_dt'] || !$_REQUEST['retry_end_dt']) {
@@ -360,56 +359,6 @@ function return_data_save($db_conn, $resData, $order_item_code,
 }
 
 
-//// 로그 파일에 기록하는 함수
-function log_write($order_item_code, $log_data, $file_name, $log_dir)
-{
-    /* 1) 경로 안전 조합 */
-    $dir = rtrim($log_dir, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
-
-    /* 2) 디렉터리 생성(775/664) */
-    $oldUmask = umask(002);
-    if (!is_dir($dir)) {
-        if (!mkdir($dir, 0775, true)) {
-            umask($oldUmask);
-            throw new RuntimeException("로그 디렉터리 생성 실패: {$dir}");
-        }
-    }
-    umask($oldUmask);
-
-    /* 3) 로그 라인 생성 */
-    $time = date('c');                                   // ISO-8601
-    $sanitized = preg_replace('/[^A-Za-z0-9_\-]/', '', $order_item_code);
-
-    if (is_string($log_data)) {
-        $body = $log_data;
-    } else {
-        $body = json_encode($log_data, JSON_UNESCAPED_UNICODE);
-        if ($body === false) {
-            // PHP 5.3~5.4에 json_last_error_msg()가 없으므로 별도 처리
-            $jsonError = function_exists('json_last_error_msg')
-                ? json_last_error_msg()
-                : 'JSON encoding error';
-            throw new RuntimeException('JSON 인코딩 실패: ' . $jsonError);
-        }
-    }
-
-    $logTxt = "\n({$sanitized} {$time})\n{$body}\n\n";
-
-    /* 4) 파일 쓰기(append + lock) */
-    $path = $dir . $file_name;
-
-    // 10 MB 초과 시 간단 로테이션
-    if (is_file($path) && filesize($path) > 10 * 1024 * 1024) {
-        rename($path, $path . '.' . date('Ymd_His'));
-    }
-
-    // LOCK_EX 상수는 PHP 5.1 이상에서 지원
-    if (file_put_contents($path, $logTxt, FILE_APPEND | LOCK_EX) === false) {
-        throw new RuntimeException("로그 파일 쓰기 실패: {$path}");
-    }
-
-    return true;
-}
 // 모든 로직이 정상적으로 완료되었을 때 아래 코드 실행
 if ($failed) {
     $cnt   = count($failed);


### PR DESCRIPTION
## Summary
- create `common.php` with database connection and `log_write` helper
- use these shared functions in `run_failed_esim_handler.php` and `run_failed_usim_handler.php`
- remove duplicated `log_write` implementations

## Testing
- `php -l run_failed_esim_handler.php` *(fails: php not installed)*
- `php -l run_failed_usim_handler.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686f73ba39d4832da6e89ef0359cf6eb